### PR TITLE
feat(kafka): initialize patient creation Kafka event producer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,12 +36,14 @@ services:
       - "4000:4000"
     environment:
       # Use billing-service as hostname, not localhost
-      - billing.service.address.localhost=billing-service
-      - billing.service.grpc.port=9001
+      - BILLING_SERVICE_ADDRESS_LOCALHOST=billing-service
+      - BILLING_SERVICE_GRPC_PORT=9001
       # PostgreSQL connection (note: use service name springboot-postgres as host)
-      - spring.datasource.url=jdbc:postgresql://springboot-postgres:5432/patient_management
-      - spring.datasource.username=myuser
-      - spring.datasource.password=mypassword
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://springboot-postgres:5432/patient_management
+      - SPRING_DATASOURCE_USERNAME=myuser
+      - SPRING_DATASOURCE_PASSWORD=mypassword
+      # Kafka 
+      - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:9092
     depends_on:
       - db
       - billing-service

--- a/patient-service/pom.xml
+++ b/patient-service/pom.xml
@@ -106,7 +106,11 @@
 			<version>6.0.53</version>
 			<scope>provided</scope>
 		</dependency>
-
+		<!-- KAFKA Setup -->
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+		</dependency>
 
 	</dependencies>
 

--- a/patient-service/src/main/java/com/pm/patientService/kafka/KafkaProducer.java
+++ b/patient-service/src/main/java/com/pm/patientService/kafka/KafkaProducer.java
@@ -1,0 +1,33 @@
+package com.pm.patientService.kafka;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import com.pm.patientService.model.Patient;
+import patient.events.PatientEvent;
+
+@Service
+public class KafkaProducer {
+    private final KafkaTemplate<String,byte[]> kafkaTemplate;
+
+    private static final Logger log = LoggerFactory.getLogger(KafkaProducer.class);
+    public KafkaProducer(KafkaTemplate<String,byte[]> kafkaTemplate){
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void sendEvent(Patient patient){
+        PatientEvent event = PatientEvent.newBuilder()
+                .setEmail(patient.getEmail())
+                .setName(patient.getName())
+                .setPatientID(patient.getId().toString())
+                .setEventType("PATIENT_CREATED")
+                .build();
+        try {
+            kafkaTemplate.send("patient",event.toByteArray());
+        }catch(Exception e){
+            log.info("Failed to produce the event {}",event);
+        }
+    }
+}

--- a/patient-service/src/main/proto/patient_event.proto
+++ b/patient-service/src/main/proto/patient_event.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package patient.events;
+
+option java_multiple_files = true;
+
+message PatientEvent {
+ string patientID = 1;
+ string name = 2;
+ string email = 3;
+ string event_type = 4;
+}

--- a/patient-service/src/main/resources/application.properties
+++ b/patient-service/src/main/resources/application.properties
@@ -5,16 +5,22 @@ spring.datasource.url=jdbc:postgresql://springboot-postgres:5432/patient_managem
 # spring.datasource.url=jdbc:postgresql://localhost:5000/patient_management 
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.username=myuser
-spring.datasource.password=mypassword
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 spring.sql.init.mode=ALWAYS
 spring.jpa.hibernate.ddl-auto=update
 server.port=4000
+
 
 logging.level.root=info
  # slf4j
 
 # application.properties
 
-billing.service.address.localhost=billing-service
-billing.service.grpc.port=9001
+billing.service.address.localhost=${BILLING_SERVICE_ADDRESS_LOCALHOST}
+billing.service.grpc.port=${BILLING_SERVICE_GRPC_PORT}
+
+# Kafka serialization
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer 
+spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.ByteArraySerializer
+


### PR DESCRIPTION
- Added KafkaProducer class to publish patient creation events.
- Configured Kafka bootstrap servers in application.properties.
- Created new proto file `patient_event.proto` for patient-related events.
- Modified `PatientServiceImpl` to send event after patient creation.
- Updated docker-compose.yml to include Kafka-related environment variables.